### PR TITLE
[fix][SETB-30]special enemy 타격범위 수정 및 switch문 수정

### DIFF
--- a/src/main/java/engine/Core.java
+++ b/src/main/java/engine/Core.java
@@ -133,27 +133,27 @@ public final class Core {
 			 * SettingScreen에서 정한 화면 사이즈에 맞추어 WIDTH, HEIGHT가 변경됨.
 			 */
 			switch (screenSizeMode) {
-				case 1 -> {
+				case 1:
 					WIDTH = 550;
 					HEIGHT = 638;
 					DrawManager.setEntitySize(3,3,3,3);
 					EnemyShip.setModiWidth(3);	// EnemyShip의 타격범위 설정
 					EnemyShipFormation.setDistance(60);
-				}
-				case 2 -> {
+					break;
+				case 2:
 					WIDTH = 710;
 					HEIGHT = 824;
 					DrawManager.setEntitySize(4,4,4,4);
 					EnemyShip.setModiWidth(4);	// EnemyShip의 타격범위 설정
 					EnemyShipFormation.setDistance(80);
-				}
-				default -> {
+					break;
+				default:
 					WIDTH = 448;
 					HEIGHT = 520;
 					DrawManager.setEntitySize(2,2,1,1);
 					EnemyShip.setModiWidth(2);	// EnemyShip의 타격범위 설정
 					EnemyShipFormation.setDistance(40);
-				}
+					break;
 			}
 
 			/**

--- a/src/main/java/entity/EnemyShip.java
+++ b/src/main/java/entity/EnemyShip.java
@@ -89,7 +89,7 @@ public class EnemyShip extends Entity {
 	 * starting properties. 생성자, 알려진 시작 속성을 사용하여 특수 함선에 대한 함선 속성을 설정합니다.
 	 */
 	public EnemyShip() {
-		super(-32, 60, 16 * 2, 7 * 2, Color.RED);
+		super(-32, 60, 16 * modiWidth, 7 * modiWidth, Color.RED);
 
 		this.spriteType = SpriteType.EnemyShipSpecial;
 		this.isDestroyed = false;


### PR DESCRIPTION
빨간색 우주선인 special enemy가 화면 사이즈가 커질 때 타격 범위도 같이 커져야 하는데 고려를 빼먹고 안해주었습니다. 수정하였습니다.
switch문도 enhanced switch 문은 14 이상부터 지원 가능하다고 해서 original switch 문으로 바꾸었습니다.